### PR TITLE
切换站点后激活站点窗口

### DIFF
--- a/app/viewManager.js
+++ b/app/viewManager.js
@@ -54,6 +54,7 @@ class ViewManager {
             if (this.views[i].name === name.toLowerCase()) {
                 this.views[i].time = timestamp;
                 this.views[i].object.setVisible(true)
+                this.views[i].object.webContents.focus();
                 eventManager.emit('set:title', this.views[i].object.webContents.getTitle());
             }else{
                 this.views[i].object.setVisible(false)


### PR DESCRIPTION
目前切换站点后如果没有重新载入只会让窗口可见但并没有给予焦点，导致站点本身设置的自动聚焦输入框、键盘快捷键等都无法生效，必须要用鼠标点击一下才行。