### PR TITLE
fix: 修复 README 中失效的 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=deepshit2025/tuboshu&type=Date)](https://www.star-history.com/#deepshit2025/tuboshu&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=deepshit2025/tuboshu&type=Date)](https://star-history.dera.page/#deepshit2025/tuboshu&Date)


### PR DESCRIPTION
当前 README 中的 Star History 图表已经失效，无法正常展示项目的 Star 趋势，需要修复。

修改内容：
- 将图表图片地址与链接更新为新的服务地址 star-history.dera.page

修复后 Star History 图表可恢复正常显示。